### PR TITLE
add separate cxx options for gcc

### DIFF
--- a/tools/cmake/mbed_toolchain.cmake
+++ b/tools/cmake/mbed_toolchain.cmake
@@ -121,6 +121,7 @@ set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_LIBRARIES 1)
 set(link_options "")
 set(common_options "")
 set(c_cxx_compile_options "") # compile options only for C/CXX
+set(cxx_compile_options "") # compile options only for CXX
 set(asm_compile_options "") # compile options only for ASM
 
 include(toolchains/${MBED_TOOLCHAIN})
@@ -140,7 +141,7 @@ endmacro(list_to_space_separated)
 
 # set toolchain flags with CMake (INIT variables will be picked up on first run)
 list_to_space_separated(CMAKE_C_FLAGS_INIT ${common_options} ${c_cxx_compile_options})
-set(CMAKE_CXX_FLAGS_INIT ${CMAKE_C_FLAGS_INIT})
+list_to_space_separated(CMAKE_CXX_FLAGS_INIT ${common_options} ${c_cxx_compile_options} ${cxx_compile_options})
 list_to_space_separated(CMAKE_ASM_FLAGS_INIT ${common_options} ${asm_compile_options})
 list_to_space_separated(CMAKE_EXE_LINKER_FLAGS_INIT ${link_options})
 

--- a/tools/cmake/toolchains/GCC_ARM.cmake
+++ b/tools/cmake/toolchains/GCC_ARM.cmake
@@ -43,6 +43,11 @@ list(APPEND common_options
     "-g3"
 )
 
+list(APPEND cxx_compile_options
+    "-Wno-register"
+    "-Wno-write-strings"
+)
+
 # Configure the toolchain to select the selected C library
 function(mbed_set_c_lib target lib_type)
     if (${lib_type} STREQUAL "small")


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).
    
-->

This is a fix for the compiler warning for using the obsolete keyword 'register' and string conversions.
The register keyword is used in CMSIS, and should be fixed by updating CMSIS to a more recent version.
The string warning maybe fixed in the mbed-os repo, but there are a lot of places where it is used, so this fix should be considered as temporary workaround.

The warnings occur because mbed-ce does not use the compile profile settings from tools/profiles and uses C++17 as language standard. Beginning with c++17, gcc throws this warnings and it could be turned into errors in the future.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.
-->

Reduces the large number of warning for an inital build

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Add an X to any of the following boxes that this PR functions as.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    This update has been tested with gcc 11.3, should be tested with ARMCC also.
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@multiplemonomials 
----------------------------------------------------------------------------------------------------------------
